### PR TITLE
Show all schema validation errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name='Flask-JsonSchema',
-    version='0.1.0',
+    version='0.2.0',
     url='https://github.com/mattupstate/flask-jsonschema',
     license='MIT',
     author='Matt Wright',


### PR DESCRIPTION
Works almost the same except all of the validation exceptions are available in exception.schema_errors instead of just the first exception being accessible
